### PR TITLE
:sparkles: GeoJSON Preview Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "naksha-components-react",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "main": "dist/index.js",
   "module": "dist/naksha.esm.js",
   "typings": "dist/index.d.ts",

--- a/src/components/map-area-draw/index.tsx
+++ b/src/components/map-area-draw/index.tsx
@@ -63,7 +63,10 @@ export default function MapAreaDraw({
   }, [features]);
 
   useEffect(() => {
-    if (isControlled) {
+    if (
+      isControlled &&
+      JSON.stringify(features) !== JSON.stringify(defaultFeatures)
+    ) {
       setFeatures(defaultFeatures);
     }
   }, [defaultFeatures]);

--- a/src/components/previewer/index.tsx
+++ b/src/components/previewer/index.tsx
@@ -1,0 +1,97 @@
+import bbox from "@turf/bbox";
+import React, { useEffect, useRef, useState } from "react";
+import MapGL, { Layer, Source, WebMercatorViewport } from "react-map-gl";
+
+import Navigation from "../../components/map/navigation";
+import { PreviewerProps } from "../../interfaces/naksha";
+import { defaultMapStyles, defaultNakshaProps } from "../../static/constants";
+import { updateWorldViewRef } from "../../utils/view";
+
+const featureStyle = {
+  id: "data",
+  type: "fill",
+  paint: {
+    "fill-color": "#f03b20",
+    "fill-opacity": 0.2
+  }
+};
+
+/**
+ * Renders Provided geojson.
+ *
+ * @export
+ * @param {PreviewerProps} {
+ *   defaultViewPort,
+ *   data,
+ *   onFeaturesChange,
+ *   baseLayer,
+ *   mapboxApiAccessToken
+ * }
+ * @returns
+ */
+export default function Previewer({
+  defaultViewPort,
+  data,
+  baseLayer,
+  mapboxApiAccessToken
+}: PreviewerProps) {
+  const mapRef = useRef(null);
+  const [viewPort, setViewPort] = useState(
+    defaultViewPort || defaultNakshaProps.viewPort
+  );
+
+  const updateViewport = () => {
+    if (!data) {
+      return;
+    }
+
+    const b = bbox(data);
+    const { longitude, latitude, zoom } = new WebMercatorViewport(
+      viewPort
+    ).fitBounds([
+      [b[0], b[1]],
+      [b[2], b[3]]
+    ]);
+
+    setViewPort(o => ({
+      ...o,
+      longitude,
+      latitude,
+      zoom: zoom - 0.2
+    }));
+  };
+
+  const onLoad = () => {
+    updateWorldViewRef(mapRef);
+    mapRef.current.getMap().on("style.load", () => {
+      updateWorldViewRef(mapRef);
+    });
+    updateViewport();
+  };
+
+  useEffect(() => {
+    updateViewport();
+  }, [data]);
+
+  return (
+    <MapGL
+      {...viewPort}
+      width="100%"
+      height="100%"
+      mapStyle={
+        defaultMapStyles[baseLayer || defaultNakshaProps.baseLayer].style
+      }
+      onLoad={onLoad}
+      ref={mapRef}
+      onViewportChange={setViewPort}
+      mapboxApiAccessToken={mapboxApiAccessToken}
+    >
+      <Navigation onViewportChange={setViewPort} />
+      {data && (
+        <Source type="geojson" data={data}>
+          <Layer {...featureStyle} />
+        </Source>
+      )}
+    </MapGL>
+  );
+}

--- a/src/hooks/use-layer-manager.tsx
+++ b/src/hooks/use-layer-manager.tsx
@@ -1,5 +1,5 @@
 import { WebMercatorViewport } from "@math.gl/web-mercator";
-import bboxPolygon from "@turf/bbox";
+import bbox from "@turf/bbox";
 import produce from "immer";
 import { debounce } from "ts-debounce";
 
@@ -97,7 +97,7 @@ export default function useLayerManager() {
     );
     set({
       element: layer[eventProp],
-      bbox: bboxPolygon(feature),
+      bbox: bbox(feature),
       feature,
       lngLat,
       layerId: layer.id

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,14 @@
 import { CSSReset, theme, ThemeProvider } from "@chakra-ui/core";
 
 import MapAreaDraw from "./components/map-area-draw";
+import Previewer from "./components/previewer";
 import {
   BaseLayer,
   ExtendedMarkerProps,
   LayerType,
   MapAreaDrawProps,
-  NakshaProps
+  NakshaProps,
+  PreviewerProps
 } from "./interfaces/naksha";
 import Naksha from "./naksha";
 import { defaultNakshaProps } from "./static/constants";
@@ -23,5 +25,7 @@ export {
   ThemeProvider,
   CSSReset,
   MapAreaDrawProps,
-  MapAreaDraw
+  MapAreaDraw,
+  PreviewerProps,
+  Previewer
 };

--- a/src/interfaces/naksha.ts
+++ b/src/interfaces/naksha.ts
@@ -97,3 +97,10 @@ export interface MapAreaDrawProps {
   isReadOnly?: boolean;
   isMultiple?: boolean;
 }
+
+export interface PreviewerProps {
+  defaultViewPort?: Partial<ViewportProps>;
+  mapboxApiAccessToken: string;
+  baseLayer?: BaseLayer;
+  data?: any;
+}

--- a/stories/previewer.stories.tsx
+++ b/stories/previewer.stories.tsx
@@ -1,0 +1,48 @@
+import { object, text, withKnobs } from "@storybook/addon-knobs";
+import React from "react";
+
+import { defaultNakshaProps, Previewer } from "../src";
+
+export default {
+  title: "Previewer",
+  decorators: [withKnobs]
+};
+
+const geojson = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [45.17, -19.31],
+            [46.93, -19.31],
+            [46.93, -17.72],
+            [45.17, -17.72],
+            [45.17, -19.31]
+          ]
+        ]
+      }
+    }
+  ]
+};
+
+export const toStorybook = () => {
+  return (
+    <Previewer
+      defaultViewPort={object("ViewPort", defaultNakshaProps.viewPort)}
+      mapboxApiAccessToken={text(
+        "Mapbox Token",
+        process.env.STORYBOOK_MAPBOX_TOKEN
+      )}
+      data={object("data", geojson)}
+    />
+  );
+};
+
+toStorybook.story = {
+  name: "previewer"
+};


### PR DESCRIPTION
### Changelog

This PR adds a new component that supports consumes `GeoJSON` as a prop and dynamically computes bounds using `@turf/bbox` and allows user to preview `GeoJSON` data

also this component supports controlled and uncontrolled behaviour that will provide slight performance advantage when updates are not needed once initial `GeoJSON` is provided